### PR TITLE
Use Next dev server and isolate Socket.IO

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,21 +5,10 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig: NextConfig = {
   /* config options here */
-  devtools: { enabled: false },
   typescript: {
     ignoreBuildErrors: true,
   },
-  // 禁用 Next.js 热重载，由 nodemon 处理重编译
   reactStrictMode: false,
-  webpack: (config, { dev }) => {
-    if (dev) {
-      // 禁用 webpack 的热模块替换
-      config.watchOptions = {
-        ignored: ['**/*'], // 忽略所有文件变化
-      };
-    }
-    return config;
-  },
   eslint: {
     // 构建时忽略ESLint错误
     ignoreDuringBuilds: true,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "nodemon --exec \"npx tsx server.ts\" --watch server.ts --watch src --ext ts,tsx,js,jsx 2>&1 | tee dev.log",
+    "dev": "next dev",
+    "socket": "node socket-server.cjs",
     "build": "next build",
     "start": "NODE_ENV=production tsx server.ts 2>&1 | tee server.log",
     "lint": "next lint",

--- a/socket-server.cjs
+++ b/socket-server.cjs
@@ -1,0 +1,40 @@
+const { createServer } = require('http');
+const { Server } = require('socket.io');
+
+const port = process.env.SOCKET_PORT || 3001;
+const server = createServer();
+
+const io = new Server(server, {
+  path: '/api/socketio',
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST']
+  }
+});
+
+io.on('connection', (socket) => {
+  console.log('Client connected:', socket.id);
+
+  socket.on('message', (msg) => {
+    socket.emit('message', {
+      text: `Echo: ${msg.text}`,
+      senderId: 'system',
+      timestamp: new Date().toISOString()
+    });
+  });
+
+  socket.on('disconnect', () => {
+    console.log('Client disconnected:', socket.id);
+  });
+
+  socket.emit('message', {
+    text: 'Welcome to WebSocket Echo Server!',
+    senderId: 'system',
+    timestamp: new Date().toISOString()
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Socket.IO server running at http://localhost:${port}`);
+});
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,12 @@ import '../../styles/globals.css';
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className="antialiased bg-background text-foreground">{children}</body>
+      <body
+        className="antialiased bg-background text-foreground"
+        suppressHydrationWarning
+      >
+        {children}
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- run development with Next's built-in server
- provide standalone Socket.IO server
- simplify Next configuration for standard development
- ignore body hydration mismatch from extension-added attributes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68accb28a17483209a710c7b4365a14f