### PR TITLE
feat: add premium card styling

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -37,6 +37,9 @@ This style guide documents the foundational design tokens and component standard
 - **Cards/Containers:** use unified border radii and shadow tokens.
 - **States:** loading, empty and error states should rely on semantic colors above.
 
+## Elevation
+- `shadow-elevation-1` through `shadow-elevation-5` provide layered shadow levels for component depth.
+
 ## Accessibility
 - All color combinations target WCAG AA (4.5:1) contrast.
 - Dark mode uses the same tokens with inverted foreground/background values.

--- a/public/noise.svg
+++ b/public/noise.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+  <filter id="noise">
+    <feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="4" stitchTiles="stitch"/>
+  </filter>
+  <rect width="100%" height="100%" filter="url(#noise)"/>
+</svg>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,9 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "relative overflow-hidden bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-elevation-2 transition-shadow hover:shadow-elevation-3",
+        "before:absolute before:inset-0 before:bg-gradient-to-br before:from-[var(--kapunka-sage-light)]/[0.15] before:to-[var(--kapunka-taupe)]/[0.15] before:pointer-events-none",
+        "after:absolute after:inset-0 after:bg-[url('/noise.svg')] after:opacity-5 after:pointer-events-none",
         className
       )}
       {...props}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -46,6 +46,13 @@ const config: Config = {
                         lg: "12px",
                         xl: "16px"
                 },
+                boxShadow: {
+                        'elevation-1': '0 1px 2px rgba(22,19,19,0.04)',
+                        'elevation-2': '0 2px 4px rgba(22,19,19,0.04), 0 1px 2px rgba(22,19,19,0.04)',
+                        'elevation-3': '0 4px 8px rgba(22,19,19,0.06), 0 2px 4px rgba(22,19,19,0.06)',
+                        'elevation-4': '0 8px 16px rgba(22,19,19,0.08), 0 4px 8px rgba(22,19,19,0.06)',
+                        'elevation-5': '0 12px 24px rgba(22,19,19,0.1), 0 8px 16px rgba(22,19,19,0.08)'
+                },
                 colors: {
                         background: 'hsl(var(--background))',
                         foreground: 'hsl(var(--foreground))',


### PR DESCRIPTION
## Summary
- add multi-level shadow tokens for consistent elevations
- enhance card component with gradient overlay and noise texture
- document new elevation tokens in style guide
- provide reusable SVG noise asset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68add43d25c48320934cef2b6e297969